### PR TITLE
show count only on specific language types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,31 @@
                 "plaintext"
                 ],
                 "description": "The languages to activate this extension. Reload to take effect."
+            },
+            "word-count.countSplitRegexp": {
+                "type": "string",
+                "default": "\\s+",
+                "description": "The regular expression to split words. Example: \\s+"
+            },
+            "word-count.countMatchRegexp": {
+                "type": "string",
+                "default": "",
+                "description": "The regular expression to match words, overriding countSplitRegexp. Example: [\\w-']+\\b"
+            },
+            "word-count.filterExcludeRegexp": {
+                "type": "string",
+                "default": "",
+                "description": "The regular expression to exclude words. It works after splitting or matching."
+            },
+            "word-count.filterEmpty": {
+                "type": "boolean",
+                "default": true,
+                "description": "Filter empty words after splitting or matching."
+            },
+            "word-count.maxCharLimit": {
+                "type": "number",
+                "default": -1,
+                "description": "The maximum number of characters to count. -1 means no limit."
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "word-count",
   "displayName": "Word Count",
   "description": "Live word count",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Oliver Kovacs",
   "license": "MIT",
   "repository": {
@@ -33,7 +33,21 @@
         "command": "word-count.details",
         "title": "Word Count: Details"
       }
-    ]
+    ],
+    "configuration": {
+        "type": "object",
+        "title": "word-count configuration",
+        "properties": {
+            "word-count.activateLanguageId": {
+                "type": "array",
+                "default": [
+                "markdown",
+                "plaintext"
+                ],
+                "description": "The languages to activate this extension. Reload to take effect."
+            }
+        }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export function activate({ subscriptions }: vscode.ExtensionContext) {
 
   // counts the number of words in a passed in string
   const count = (text: string): number => {
-    return (text.match(/[a-zA-Z0-9]+/g) || []).length;
+    return (text.match(/[\w-]+(?<!-)\b/g) || []).length;
   };
 
   // gets the document from the active text editor, and then returns the text in the document. If text is selected, return that text instead


### PR DESCRIPTION
Feature: show count only on specific language types, and it is configurable. By default they are markdown and plaintext. 
Bug fix:  use another way to count words, which is more accurate for English. 